### PR TITLE
chore: ckad course update readme and fix deprecations

### DIFF
--- a/examples/kubernetes/deployments/nginx-deployment.yaml
+++ b/examples/kubernetes/deployments/nginx-deployment.yaml
@@ -14,8 +14,8 @@ spec:
     spec:
       containers:
       - name: nginx
-        #image: registry.sighup.io/workshop/nginx:1.7.9
-        image: registry.sighup.io/workshop/nginx:1.9.1
+        image: registry.sighup.io/workshop/nginx:1.7.9
+        # image: registry.sighup.io/workshop/nginx:1.9.1
         # image: registry.sighup.io/workshop/nginx:1.91
         ports:
         - containerPort: 80

--- a/examples/kubernetes/network-policy/README.md
+++ b/examples/kubernetes/network-policy/README.md
@@ -46,7 +46,7 @@ kubectl exec backend -n test -- curl frontend
 7. Create a `default-deny` network policy both from Ingress and Egress.
 
 ```bash
-kubectl apply -f network-policy/default_deny.yaml
+kubectl apply -f default_deny.yaml
 ```
 8. Check connectivity again
 

--- a/examples/kubernetes/power-app/workshop/ingress-web.yaml
+++ b/examples/kubernetes/power-app/workshop/ingress-web.yaml
@@ -4,11 +4,10 @@ kind: Ingress
 metadata:
   name: web
   namespace: dev
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
   labels:
     app: powerapp-web
 spec:
+  ingressClassName: nginx
   rules:
     - host: web.test.example
       http:


### PR DESCRIPTION
This PR aims to fix some minor problems found during the review of the CKAD course. This would result in a better experience for students when they will resolve labs assignments.

## Details ⚙️ 
Here a list of changes:
- Fix initial image version in `examples/kubernetes/deployments/nginx-deployment.yaml`
- Replace deprecated annotation on ingress `examples/kubernetes/power-app/workshop/ingress-web.yaml`
- Replace path for `default_deny.yaml` policy apply in `examples/kubernetes/network-policy/README.md`

## Breaking Changes 💔 
There are no breaking changes.