### PR TITLE
fix(example): fix cli command in kubernetes/example-app

### DIFF
--- a/examples/kubernetes/example-app/README.md
+++ b/examples/kubernetes/example-app/README.md
@@ -170,5 +170,5 @@ kubectl exec -it imaginarygame-c587857bf-mrxzd -- ls /etc/game-secrets
 Let's clean:
 
 ```bash
-kubectl delete -f configmaps/cm.yaml example-app/secret.yaml example-app/web-env.yaml configmaps/deploy.yaml
+kubectl delete -f configmaps/cm.yaml -f example-app/secret.yaml -f example-app/web-env.yaml -f configmaps/deploy.yaml
 ```


### PR DESCRIPTION
This pull request makes a minor update to the Kubernetes cleanup command in the `README.md` file to improve clarity and correctness. The change ensures that each file is specified with the `-f` flag, which is required for proper deletion.

* Updated the cleanup command in `examples/kubernetes/example-app/README.md` to use `-f` for each file, ensuring correct syntax for deleting multiple resources.